### PR TITLE
依頼者が基本情報収集フォームを提出していない場合、Slack IDがわからずワークフローへの送信が完了しない不具合を修正しました。

### DIFF
--- a/note.html
+++ b/note.html
@@ -10,8 +10,10 @@ slackWorkflow_notifyRequest_WebReqestUrl -> ワークフロー(本番環境用)�
 slackWorkflow_test_WebReqestUrl -> ワークフロー(テスト環境用)のWebRequestUrl(ワークフローの管理画面から取得可)
 slackbot_botUserOAuthToken -> 使用していません
 systemManagerEmails -> システム管理者の方のメールアドレス(複数ある場合は,で区切ってください)
+slackAdminEmail -> システム管理者の中でSlackに存在するユーザーのメールアドレス(一人のみ)
 sheetId_resource -> リソース管理シートのファイルID
 
 ▼説明書
-https://docs.google.com/document/d/1xx777pZ7r8vM7kIFn8K9WZ_Ozk4RnebB-H-ppQhe_s0/edit?usp=sharing
+https://github.com/teppGreen/n-highschool_magfes_creative
+システム管理者は全員基本情報収集フォームを提出してください。
 ※アクセス権限がない場合は、お手数をおかけしますがリクエストをお願いします。


### PR DESCRIPTION
2つパラメータを追加しました。移行前に設定が必要です。

【リソース管理シートのGASのスクリプトプロパティ】
Key: slackAdminEmail
Value: (システム管理者の中でSlackに存在するユーザーのメールアドレス(一人のみ))

【リソース管理シート＞parametersタブ】
Key: registrationForm.id
Value: (基本情報収集フォームの回答URLのID部分)